### PR TITLE
Added support for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
 
-cache: pip
+python: 3.5
 env:
+    - TOXENV=py27
+    - TOXENV=py34
+    - TOXENV=py35
     - TOXENV=pep8
 before_install:
     - pip install --upgrade pip setuptools
 install:
     - pip install tox
+    - if [ "$TOXENV" = 'py27' ]; then pip install coveralls; fi
 script:
     - tox -e $TOXENV
+after_success:
+    - if [ "$TOXENV" = 'py27' ]; then coveralls; fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[pytest]
-testpaths = morepath_wiki

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: WSGI',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,20 @@
 [tox]
-envlist = pep8
+envlist = py27,py34,py35,pep8
+
+[testenv]
+deps = -e{toxinidir}[test]
+commands = py.test {posargs}
+
+[testenv:py27]
+commands = py.test --cov morepath_wiki {posargs}
 
 [testenv:pep8]
 basepython = python2
 deps = flake8
-commands = flake8
+commands = flake8 morepath_wiki setup.py
+
+[pytest]
+testpaths = morepath_wiki
+
+[flake8]
+exclude = morepath_wiki/html.py


### PR DESCRIPTION
- Set up the following services/tools:
  * Coverall
  * Flake8
  * Pytest
  * Tox
  * Travis CI

- Added support for Python 3.5