### PR TITLE
Python support update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: python
 
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
-env:
-    - TOXENV=py36
-    - TOXENV=py37
-    - TOXENV=py38
-    - TOXENV=pep8
-    - TOXENV=coverage
+python: 3.8
+
+cache: pip
+
 matrix:
     include:
         - python: "3.6"
@@ -26,5 +20,8 @@ before_install:
     - pip install --upgrade pip setuptools
 install:
     - pip install tox
+    - if [ "$TOXENV" = 'coverage' ]; then pip install coveralls; fi
 script:
     - tox -e $TOXENV
+after_success:
+    - if [ "$TOXENV" = 'coverage' ]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,27 @@
 language: python
 
-python: 3.5
+python:
+    - "3.6"
+    - "3.7"
+    - "3.8"
 env:
-    - TOXENV=py27
-    - TOXENV=py34
-    - TOXENV=py35
+    - TOXENV=py36
+    - TOXENV=py37
+    - TOXENV=py38
     - TOXENV=pep8
     - TOXENV=coverage
+matrix:
+    include:
+        - python: "3.6"
+          env: TOXENV=py36
+        - python: "3.7"
+          env: TOXENV=py37
+        - python: "3.8"
+          env: TOXENV=py38
+        - python: "3.8"
+          env: TOXENV=pep8
+        - python: "3.8"
+          env: TOXENV=coverage
 before_install:
     - pip install --upgrade pip setuptools
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGES
 0.2 (unreleased)
 ================
 
-- Make Python 3.5 the default testing environment.
+- Make Python 3.6 the default testing environment.
 
 
 0.1 (2016-06-09)

--- a/morepath_wiki/html.py
+++ b/morepath_wiki/html.py
@@ -227,7 +227,7 @@ from __future__ import with_statement
 __version__ = '1.16'
 
 import sys
-import cgi
+import html as py_html
 import unittest
 
 
@@ -293,7 +293,7 @@ class HTML(object):
         special to HTML will be escaped.
         '''
         if escape:
-            text = cgi.escape(text)
+            text = py_html.escape(text)
         # adding text
         if self._top:
             self._stack[-1]._content.append(text)
@@ -319,7 +319,7 @@ class HTML(object):
         escape = kw.pop('escape', True)
         if content:
             if escape:
-                self._content = list(map(cgi.escape, content))
+                self._content = list(map(py_html.escape, content))
             else:
                 self._content = content
         if 'newlines' in kw:
@@ -327,9 +327,9 @@ class HTML(object):
             self._newlines = kw.pop('newlines')
         for k in kw:
             if k == 'klass':
-                self._attrs['class'] = cgi.escape(kw[k], True)
+                self._attrs['class'] = py_html.escape(kw[k], True)
             else:
-                self._attrs[k] = cgi.escape(kw[k], True)
+                self._attrs[k] = py_html.escape(kw[k], True)
         return self
 
     def __enter__(self):

--- a/morepath_wiki/storage.py
+++ b/morepath_wiki/storage.py
@@ -1,6 +1,6 @@
 # reusable storage implementation for wiki taken from here
 # https://bitbucket.org/r1chardj0n3s/web-micro-battle/
-import cgi
+import html as py_html
 import os
 import re
 import stat
@@ -8,11 +8,11 @@ import time
 
 from . import html
 
-wikiname_re = re.compile('((?<![a-z\d])([A-Z][a-z]+([A-Z][a-z]+|\d+)+))')
+wikiname_re = re.compile(r'((?<![a-z\d])([A-Z][a-z]+([A-Z][a-z]+|\d+)+))')
 
 
 def wikify(text):
-    return wikiname_re.sub(r'<a href="/\1">\1</a>', cgi.escape(text))
+    return wikiname_re.sub(r'<a href="/\1">\1</a>', py_html.escape(text))
 
 
 class Storage(object):
@@ -135,8 +135,8 @@ class Storage(object):
         h.p('Select version to revert to.')
         f = h.form(action='/%s/history' % name, method='POST')
         for version, ts in self.list_page_versions(name):
-            l = f.li(time.asctime(time.localtime(ts)))
-            l.input(type='radio', value=str(version), name='version')
+            li = f.li(time.asctime(time.localtime(ts)))
+            li.input(type='radio', value=str(version), name='version')
         f.br
         f.input(type='submit', name='submit', value='Revert To Selected')
         f.input(type='submit', name='cancel', value='Cancel')

--- a/morepath_wiki/view.py
+++ b/morepath_wiki/view.py
@@ -8,6 +8,7 @@ from .app import App
 def index(self, request):
     return redirect(request.link(Page('FrontPage')))
 
+
 with App.html(model=Page) as html:
     @html()
     def display(self, request):

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             'pytest',
             'pytest-cov',
             'webtest',
+            'tox',
         ],
     ),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,8 @@ setup(
         'Environment :: Web Environment',
         'License :: OSI Approved :: BSD License',
         'Topic :: Internet :: WWW/HTTP :: WSGI',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
-envlist = py27,py34,py35,pep8,coverage
+envlist = py36,py37,py38,pep8,coverage
 
 [testenv]
 deps = -e{toxinidir}[test]
 commands = py.test {posargs}
 
 [testenv:pep8]
-basepython = python2
+basepython = python3.6
 deps = flake8
 commands = flake8 morepath_wiki setup.py
 
 [testenv:coverage]
-basepython = python3.5
+basepython = python3.6
 deps = {[testenv]deps}
 commands =
-    coverage run --source morepath_wiki -m py.test {posargs}
+    coverage run --source morepath_wiki -m pytest {posargs}
     coverage report -m --fail-under=100
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,14 @@ deps = -e{toxinidir}[test]
 commands = py.test {posargs}
 
 [testenv:pep8]
-basepython = python3.6
-deps = flake8
+basepython = python3.8
+deps = {[testenv]deps}
+	   flake8
+       pep8
 commands = flake8 morepath_wiki setup.py
 
 [testenv:coverage]
-basepython = python3.6
+basepython = python3.8
 deps = {[testenv]deps}
 commands =
     coverage run --source morepath_wiki -m pytest {posargs}


### PR DESCRIPTION
This merge request updates the minimal Python version to 3.6 and adds 3.8.

It also adds the tools required to run the tests to list of dependencies as well as fixes Python 3.7 warnings that are errors in Python 3.8.

Fixes #5 