### PR TITLE
Add black for Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black

--- a/morepath_wiki/__main__.py
+++ b/morepath_wiki/__main__.py
@@ -5,7 +5,8 @@ from .app import App
 def default_storage_directory():
     """Use a directory 'contents' in the current working directory."""
     import os
-    path = './contents'
+
+    path = "./contents"
     try:
         os.mkdir(path)
     except OSError:
@@ -14,11 +15,11 @@ def default_storage_directory():
     return os.path.abspath(path)
 
 
-def run():   # pragma: no cover
-    App.setting('storage', 'path')(default_storage_directory)
+def run():  # pragma: no cover
+    App.setting("storage", "path")(default_storage_directory)
     morepath.autoscan()
     morepath.run(App())
 
 
-if __name__ == '__main__':   # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     run()

--- a/morepath_wiki/app.py
+++ b/morepath_wiki/app.py
@@ -3,7 +3,6 @@ from . import storage
 
 
 class App(morepath.App):
-
     @morepath.reify
     def wiki(self):
         return storage.Storage(self.settings.storage.path)

--- a/morepath_wiki/html.py
+++ b/morepath_wiki/html.py
@@ -3,7 +3,7 @@
 # $Id: html.py 5409 2011-06-29 07:07:25Z rjones $
 # $HeadURL: svn+ssh://svn/svn/trunk/api/eklib/html.py $
 #
-'''Simple, elegant HTML, XHTML and XML generation.
+"""Simple, elegant HTML, XHTML and XML generation.
 
 Constructing your HTML
 ----------------------
@@ -222,9 +222,10 @@ please indicate so at https://www.ohloh.net/p/pyhtml
 This code is copyright 2009-2011 eKit.com Inc (http://www.ekit.com/)
 See the end of the source file for the license of use.
 XHTML support was contributed by Michael Haubenwallner.
-'''
+"""
 from __future__ import with_statement
-__version__ = '1.16'
+
+__version__ = "1.16"
 
 import sys
 import html as py_html
@@ -232,7 +233,7 @@ import unittest
 
 
 class HTML(object):
-    '''Easily generate HTML.
+    """Easily generate HTML.
 
     >>> print HTML('html', 'some text')
     <html>some text</html>
@@ -249,11 +250,11 @@ class HTML(object):
     <p>some text</p>
     <p>some text</p>
 
-    '''
-    newline_default_on = set('table ol ul dl'.split())
+    """
 
-    def __init__(self, name=None, text=None, stack=None, newlines=True,
-            escape=True):
+    newline_default_on = set("table ol ul dl".split())
+
+    def __init__(self, name=None, text=None, stack=None, newlines=True, escape=True):
         self._name = name
         self._content = []
         self._attrs = {}
@@ -271,8 +272,8 @@ class HTML(object):
 
     def __getattr__(self, name):
         # adding a new tag or newline
-        if name == 'newline':
-            e = '\n'
+        if name == "newline":
+            e = "\n"
         else:
             e = self.__class__(name, stack=self._stack)
         if self._top:
@@ -289,9 +290,9 @@ class HTML(object):
         return self
 
     def text(self, text, escape=True):
-        '''Add text to the document. If "escape" is True any characters
+        """Add text to the document. If "escape" is True any characters
         special to HTML will be escaped.
-        '''
+        """
         if escape:
             text = py_html.escape(text)
         # adding text
@@ -301,33 +302,33 @@ class HTML(object):
             self._content.append(text)
 
     def raw_text(self, text):
-        '''Add raw, unescaped text to the document. This is useful for
+        """Add raw, unescaped text to the document. This is useful for
         explicitly adding HTML code or entities.
-        '''
+        """
         return self.text(text, escape=False)
 
     def __call__(self, *content, **kw):
-        if self._name == 'read':
+        if self._name == "read":
             if len(content) == 1 and isinstance(content[0], int):
-                raise TypeError('you appear to be calling read(%d) on '
-                    'a HTML instance' % content)
+                raise TypeError(
+                    "you appear to be calling read(%d) on " "a HTML instance" % content
+                )
             elif len(content) == 0:
-                raise TypeError('you appear to be calling read() on a '
-                    'HTML instance')
+                raise TypeError("you appear to be calling read() on a " "HTML instance")
 
         # customising a tag with content or attributes
-        escape = kw.pop('escape', True)
+        escape = kw.pop("escape", True)
         if content:
             if escape:
                 self._content = list(map(py_html.escape, content))
             else:
                 self._content = content
-        if 'newlines' in kw:
+        if "newlines" in kw:
             # special-case to allow control over newlines
-            self._newlines = kw.pop('newlines')
+            self._newlines = kw.pop("newlines")
         for k in kw:
-            if k == 'klass':
-                self._attrs['class'] = py_html.escape(kw[k], True)
+            if k == "klass":
+                self._attrs["class"] = py_html.escape(kw[k], True)
             else:
                 self._attrs[k] = py_html.escape(kw[k], True)
         return self
@@ -342,19 +343,19 @@ class HTML(object):
         self._stack.pop()
 
     def __repr__(self):
-        return '<HTML %s 0x%x>' % (self._name, id(self))
+        return "<HTML %s 0x%x>" % (self._name, id(self))
 
     def _stringify(self, str_type):
         # turn me and my content into text
-        join = '\n' if self._newlines else ''
+        join = "\n" if self._newlines else ""
         if self._name is None:
             return join.join(map(str_type, self._content))
         a = ['%s="%s"' % i for i in self._attrs.items()]
         l = [self._name] + a
-        s = '<%s>%s' % (' '.join(l), join)
+        s = "<%s>%s" % (" ".join(l), join)
         if self._content:
             s += join.join(map(str_type, self._content))
-            s += join + '</%s>' % self._name
+            s += join + "</%s>" % self._name
         return s
 
     def __str__(self):
@@ -368,136 +369,142 @@ class HTML(object):
 
 
 class XHTML(HTML):
-    '''Easily generate XHTML.
-    '''
-    empty_elements = set('base meta link hr br param img area input col \
-        colgroup basefont isindex frame'.split())
+    """Easily generate XHTML."""
+
+    empty_elements = set(
+        "base meta link hr br param img area input col \
+        colgroup basefont isindex frame".split()
+    )
 
     def _stringify(self, str_type):
         # turn me and my content into text
         # honor empty and non-empty elements
-        join = '\n' if self._newlines else ''
+        join = "\n" if self._newlines else ""
         if self._name is None:
             return join.join(map(str_type, self._content))
         a = ['%s="%s"' % i for i in self._attrs.items()]
         l = [self._name] + a
-        s = '<%s>%s' % (' '.join(l), join)
-        if self._content or not(self._name.lower() in self.empty_elements):
+        s = "<%s>%s" % (" ".join(l), join)
+        if self._content or not (self._name.lower() in self.empty_elements):
             s += join.join(map(str_type, self._content))
-            s += join + '</%s>' % self._name
+            s += join + "</%s>" % self._name
         else:
-            s = '<%s />%s' % (' '.join(l), join)
+            s = "<%s />%s" % (" ".join(l), join)
         return s
 
 
 class XML(XHTML):
-    '''Easily generate XML.
+    """Easily generate XML.
 
     All tags with no contents are reduced to self-terminating tags.
-    '''
-    newline_default_on = set()          # no tags are special
+    """
+
+    newline_default_on = set()  # no tags are special
 
     def _stringify(self, str_type):
         # turn me and my content into text
         # honor empty and non-empty elements
-        join = '\n' if self._newlines else ''
+        join = "\n" if self._newlines else ""
         if self._name is None:
             return join.join(map(str_type, self._content))
         a = ['%s="%s"' % i for i in self._attrs.items()]
         l = [self._name] + a
-        s = '<%s>%s' % (' '.join(l), join)
+        s = "<%s>%s" % (" ".join(l), join)
         if self._content:
             s += join.join(map(str_type, self._content))
-            s += join + '</%s>' % self._name
+            s += join + "</%s>" % self._name
         else:
-            s = '<%s />%s' % (' '.join(l), join)
+            s = "<%s />%s" % (" ".join(l), join)
         return s
 
 
 class TestCase(unittest.TestCase):
     def test_empty_tag(self):
-        'generation of an empty HTML tag'
-        self.assertEquals(str(HTML().br), '<br>')
+        "generation of an empty HTML tag"
+        self.assertEquals(str(HTML().br), "<br>")
 
     def test_empty_tag_xml(self):
-        'generation of an empty XHTML tag'
-        self.assertEquals(str(XHTML().br), '<br />')
+        "generation of an empty XHTML tag"
+        self.assertEquals(str(XHTML().br), "<br />")
 
     def test_tag_add(self):
-        'test top-level tag creation'
-        self.assertEquals(str(HTML('html', 'text')), '<html>\ntext\n</html>')
+        "test top-level tag creation"
+        self.assertEquals(str(HTML("html", "text")), "<html>\ntext\n</html>")
 
     def test_tag_add_no_newline(self):
-        'test top-level tag creation'
-        self.assertEquals(str(HTML('html', 'text', newlines=False)),
-            '<html>text</html>')
+        "test top-level tag creation"
+        self.assertEquals(
+            str(HTML("html", "text", newlines=False)), "<html>text</html>"
+        )
 
     def test_iadd_tag(self):
         "test iadd'ing a tag"
-        h = XML('xml')
-        h += XML('some-tag', 'spam', newlines=False)
-        h += XML('text', 'spam', newlines=False)
-        self.assertEquals(str(h),
-            '<xml>\n<some-tag>spam</some-tag>\n<text>spam</text>\n</xml>')
+        h = XML("xml")
+        h += XML("some-tag", "spam", newlines=False)
+        h += XML("text", "spam", newlines=False)
+        self.assertEquals(
+            str(h), "<xml>\n<some-tag>spam</some-tag>\n<text>spam</text>\n</xml>"
+        )
 
     def test_iadd_text(self):
         "test iadd'ing text"
-        h = HTML('html', newlines=False)
-        h += 'text'
-        h += 'text'
-        self.assertEquals(str(h), '<html>texttext</html>')
+        h = HTML("html", newlines=False)
+        h += "text"
+        h += "text"
+        self.assertEquals(str(h), "<html>texttext</html>")
 
     def test_xhtml_match_tag(self):
-        'check forced generation of matching tag when empty'
-        self.assertEquals(str(XHTML().p), '<p></p>')
+        "check forced generation of matching tag when empty"
+        self.assertEquals(str(XHTML().p), "<p></p>")
 
     if sys.version_info[0] == 2:
+
         def test_empty_tag_unicode(self):
-            'generation of an empty HTML tag'
-            self.assertEquals(unicode(HTML().br), unicode('<br>'))
+            "generation of an empty HTML tag"
+            self.assertEquals(unicode(HTML().br), unicode("<br>"))
 
         def test_empty_tag_xml_unicode(self):
-            'generation of an empty XHTML tag'
-            self.assertEquals(unicode(XHTML().br), unicode('<br />'))
+            "generation of an empty XHTML tag"
+            self.assertEquals(unicode(XHTML().br), unicode("<br />"))
 
         def test_xhtml_match_tag_unicode(self):
-            'check forced generation of matching tag when empty'
-            self.assertEquals(unicode(XHTML().p), unicode('<p></p>'))
+            "check forced generation of matching tag when empty"
+            self.assertEquals(unicode(XHTML().p), unicode("<p></p>"))
 
     def test_just_tag(self):
-        'generate HTML for just one tag'
-        self.assertEquals(str(HTML().br), '<br>')
+        "generate HTML for just one tag"
+        self.assertEquals(str(HTML().br), "<br>")
 
     def test_just_tag_xhtml(self):
-        'generate XHTML for just one tag'
-        self.assertEquals(str(XHTML().br), '<br />')
+        "generate XHTML for just one tag"
+        self.assertEquals(str(XHTML().br), "<br />")
 
     def test_xml(self):
-        'generate XML'
-        self.assertEquals(str(XML().br), '<br />')
-        self.assertEquals(str(XML().p), '<p />')
-        self.assertEquals(str(XML().br('text')), '<br>text</br>')
+        "generate XML"
+        self.assertEquals(str(XML().br), "<br />")
+        self.assertEquals(str(XML().p), "<p />")
+        self.assertEquals(str(XML().br("text")), "<br>text</br>")
 
     def test_para_tag(self):
-        'generation of a tag with contents'
+        "generation of a tag with contents"
         h = HTML()
-        h.p('hello')
-        self.assertEquals(str(h), '<p>hello</p>')
+        h.p("hello")
+        self.assertEquals(str(h), "<p>hello</p>")
 
     def test_escape(self):
-        'escaping of special HTML characters in text'
+        "escaping of special HTML characters in text"
         h = HTML()
-        h.text('<>&')
-        self.assertEquals(str(h), '&lt;&gt;&amp;')
+        h.text("<>&")
+        self.assertEquals(str(h), "&lt;&gt;&amp;")
 
     def test_no_escape(self):
-        'no escaping of special HTML characters in text'
+        "no escaping of special HTML characters in text"
         h = HTML()
-        h.text('<>&', False)
-        self.assertEquals(str(h), '<>&')
+        h.text("<>&", False)
+        self.assertEquals(str(h), "<>&")
 
     def test_escape_attr(self):
-        'escaping of special HTML characters in attributes'
+        "escaping of special HTML characters in attributes"
         h = HTML()
         h.br(id='<>&"')
         self.assertEquals(str(h), '<br id="&lt;&gt;&amp;&quot;">')
@@ -506,91 +513,93 @@ class TestCase(unittest.TestCase):
         'generation of sub-tags using "with" context'
         h = HTML()
         with h.ol:
-            h.li('foo')
-            h.li('bar')
-        self.assertEquals(str(h), '<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>')
+            h.li("foo")
+            h.li("bar")
+        self.assertEquals(str(h), "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>")
 
     def test_subtag_direct(self):
-        'generation of sub-tags directly on the parent tag'
+        "generation of sub-tags directly on the parent tag"
         h = HTML()
         l = h.ol
-        l.li('foo')
-        l.li.b('bar')
-        self.assertEquals(str(h),
-            '<ol>\n<li>foo</li>\n<li><b>bar</b></li>\n</ol>')
+        l.li("foo")
+        l.li.b("bar")
+        self.assertEquals(str(h), "<ol>\n<li>foo</li>\n<li><b>bar</b></li>\n</ol>")
 
     def test_subtag_direct_context(self):
         'generation of sub-tags directly on the parent tag in "with" context'
         h = HTML()
         with h.ol as l:
-            l.li('foo')
-            l.li.b('bar')
-        self.assertEquals(str(h),
-            '<ol>\n<li>foo</li>\n<li><b>bar</b></li>\n</ol>')
+            l.li("foo")
+            l.li.b("bar")
+        self.assertEquals(str(h), "<ol>\n<li>foo</li>\n<li><b>bar</b></li>\n</ol>")
 
     def test_subtag_no_newlines(self):
-        'prevent generation of newlines against default'
+        "prevent generation of newlines against default"
         h = HTML()
         l = h.ol(newlines=False)
-        l.li('foo')
-        l.li('bar')
-        self.assertEquals(str(h), '<ol><li>foo</li><li>bar</li></ol>')
+        l.li("foo")
+        l.li("bar")
+        self.assertEquals(str(h), "<ol><li>foo</li><li>bar</li></ol>")
 
     def test_add_text(self):
-        'add text to a tag'
+        "add text to a tag"
         h = HTML()
-        p = h.p('hello, world!\n')
-        p.text('more text')
-        self.assertEquals(str(h), '<p>hello, world!\nmore text</p>')
+        p = h.p("hello, world!\n")
+        p.text("more text")
+        self.assertEquals(str(h), "<p>hello, world!\nmore text</p>")
 
     def test_add_text_newlines(self):
-        'add text to a tag with newlines for prettiness'
+        "add text to a tag with newlines for prettiness"
         h = HTML()
-        p = h.p('hello, world!', newlines=True)
-        p.text('more text')
-        self.assertEquals(str(h), '<p>\nhello, world!\nmore text\n</p>')
+        p = h.p("hello, world!", newlines=True)
+        p.text("more text")
+        self.assertEquals(str(h), "<p>\nhello, world!\nmore text\n</p>")
 
     def test_doc_newlines(self):
-        'default document adding newlines between tags'
+        "default document adding newlines between tags"
         h = HTML()
         h.br
         h.br
-        self.assertEquals(str(h), '<br>\n<br>')
+        self.assertEquals(str(h), "<br>\n<br>")
 
     def test_doc_no_newlines(self):
-        'prevent document adding newlines between tags'
+        "prevent document adding newlines between tags"
         h = HTML(newlines=False)
         h.br
         h.br
-        self.assertEquals(str(h), '<br><br>')
+        self.assertEquals(str(h), "<br><br>")
 
     def test_unicode(self):
-        'make sure unicode input works and results in unicode output'
+        "make sure unicode input works and results in unicode output"
         h = HTML(newlines=False)
         # Python 3 compat
         try:
             unicode = unicode
-            TEST = 'euro \xe2\x82\xac'.decode('utf8')
+            TEST = "euro \xe2\x82\xac".decode("utf8")
         except:
             unicode = str
-            TEST = 'euro €'
+            TEST = "euro €"
         h.p(TEST)
-        self.assertEquals(unicode(h), '<p>%s</p>' % TEST)
+        self.assertEquals(unicode(h), "<p>%s</p>" % TEST)
 
     def test_table(self):
         'multiple "with" context blocks'
         h = HTML()
-        with h.table(border='1'):
+        with h.table(border="1"):
             for i in range(2):
                 with h.tr:
-                    h.td('column 1')
-                    h.td('column 2')
-        self.assertEquals(str(h), '''<table border="1">
+                    h.td("column 1")
+                    h.td("column 2")
+        self.assertEquals(
+            str(h),
+            """<table border="1">
 <tr><td>column 1</td><td>column 2</td></tr>
 <tr><td>column 1</td><td>column 2</td></tr>
-</table>''')
+</table>""",
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()
 
 

--- a/morepath_wiki/path.py
+++ b/morepath_wiki/path.py
@@ -3,12 +3,12 @@ from .app import App
 from .model import Root, Page
 
 
-@App.path(model=Root, path='/')
+@App.path(model=Root, path="/")
 def get_root():
     return Root()
 
 
-@App.path(model=Page, path='{name}')
+@App.path(model=Page, path="{name}")
 def get_page(name):
     if not storage.wikiname_re.match(name):
         return None

--- a/morepath_wiki/storage.py
+++ b/morepath_wiki/storage.py
@@ -8,7 +8,7 @@ import time
 
 from . import html
 
-wikiname_re = re.compile(r'((?<![a-z\d])([A-Z][a-z]+([A-Z][a-z]+|\d+)+))')
+wikiname_re = re.compile(r"((?<![a-z\d])([A-Z][a-z]+([A-Z][a-z]+|\d+)+))")
 
 
 def wikify(text):
@@ -20,41 +20,41 @@ class Storage(object):
         self.directory = directory
 
     def get_current(self, title, create=False):
-        current_file = os.path.join(self.directory, title, 'current')
+        current_file = os.path.join(self.directory, title, "current")
         if os.path.exists(current_file):
             with open(current_file) as f:
                 version_file = f.read()
             version = os.path.basename(version_file)
-            version = version.split('-')[1]
+            version = version.split("-")[1]
         elif not create:
             raise KeyError(title)
         else:
             os.mkdir(os.path.join(self.directory, title))
             # os.path.join(self.directory, title, 'version-1')
-            version_file = ''
-            version = '0'
+            version_file = ""
+            version = "0"
 
         return current_file, version_file, version
 
     def update_current(self, title, version_file):
-        current_file = os.path.join(self.directory, title, 'current')
+        current_file = os.path.join(self.directory, title, "current")
         if os.path.exists(current_file):
             os.remove(current_file)
 
         # move the current version
-        with open(current_file, 'w') as f:
+        with open(current_file, "w") as f:
             f.write(version_file)
 
     def store_page(self, title, content):
-        current, version_file, version = self.get_current(title,
-                                                          create=True)
+        current, version_file, version = self.get_current(title, create=True)
 
         # new version
         new_version = int(version) + 1
-        version_file = os.path.join(self.directory, title,
-                                    'version-%d' % new_version)
+        version_file = os.path.join(
+            self.directory, title, "version-%d" % new_version
+        )
 
-        with open(version_file, 'w') as f:
+        with open(version_file, "w") as f:
             f.write(content)
 
         self.update_current(title, version_file)
@@ -68,7 +68,7 @@ class Storage(object):
         if version is None:
             current_file, version_file, version = self.get_current(title)
         else:
-            version_file = os.path.join(dir, 'version-%s' % version)
+            version_file = os.path.join(dir, "version-%s" % version)
             if not os.path.exists(version_file):
                 raise KeyError(version_file)
 
@@ -77,12 +77,12 @@ class Storage(object):
         return content
 
     def revert_page(self, title, version):
-        current_file = os.path.join(self.directory, title, 'current')
+        current_file = os.path.join(self.directory, title, "current")
         if not os.path.exists(current_file):
             raise KeyError(title)
 
-        version = os.path.join(self.directory, title, 'version-%s' % version)
-        with open(current_file, 'w') as f:
+        version = os.path.join(self.directory, title, "version-%s" % version)
+        with open(current_file, "w") as f:
             f.write(version)
 
     def list_page_versions(self, title):
@@ -91,12 +91,13 @@ class Storage(object):
             raise KeyError(title)
 
         # determine the current version
-        current_file, version_file, version = self.get_current(title,
-                                                               create=True)
+        current_file, version_file, version = self.get_current(
+            title, create=True
+        )
 
         versions = []
         for i in range(int(version)):
-            path = os.path.join(dir, 'version-%d' % (i + 1))
+            path = os.path.join(dir, "version-%d" % (i + 1))
             mtime = os.stat(path)[stat.ST_MTIME]
             versions.append((mtime, str(i + 1)))
         versions.sort()
@@ -106,38 +107,38 @@ class Storage(object):
         try:
             content = self.retrieve_page(name)
         except KeyError:
-            content = 'Page does not exist: edit to create it.'
+            content = "Page does not exist: edit to create it."
         h = html.HTML()
-        h.h1(name, id='title')
-        h.pre(wikify(content), escape=False, id='content')
-        h.a('edit this page', href='/%s/edit' % name, id='edit-link')
+        h.h1(name, id="title")
+        h.pre(wikify(content), escape=False, id="content")
+        h.a("edit this page", href="/%s/edit" % name, id="edit-link")
         h.br
-        h.a('page history', href='/%s/history' % name, id='history-link')
+        h.a("page history", href="/%s/history" % name, id="history-link")
         return str(h)
 
     def render_edit_form(self, name):
         try:
             content = self.retrieve_page(name)
         except KeyError:
-            content = 'Page does not exist: edit to create it.'
+            content = "Page does not exist: edit to create it."
         h = html.HTML()
-        h.h1('Editing ' + name, id='title')
-        f = h.form(action='/%s/edit' % name, method='POST')
-        f.textarea(content, rows='10', cols='60', name='content')
+        h.h1("Editing " + name, id="title")
+        f = h.form(action="/%s/edit" % name, method="POST")
+        f.textarea(content, rows="10", cols="60", name="content")
         f.br
-        f.input(type='submit', name='submit', value='Save Changes')
-        f.input(type='submit', name='cancel', value='Cancel')
+        f.input(type="submit", name="submit", value="Save Changes")
+        f.input(type="submit", name="cancel", value="Cancel")
         return str(h)
 
     def render_history_form(self, name):
         h = html.HTML()
-        h.h1('History For ' + name, id='title')
-        h.p('Select version to revert to.')
-        f = h.form(action='/%s/history' % name, method='POST')
+        h.h1("History For " + name, id="title")
+        h.p("Select version to revert to.")
+        f = h.form(action="/%s/history" % name, method="POST")
         for version, ts in self.list_page_versions(name):
             li = f.li(time.asctime(time.localtime(ts)))
-            li.input(type='radio', value=str(version), name='version')
+            li.input(type="radio", value=str(version), name="version")
         f.br
-        f.input(type='submit', name='submit', value='Revert To Selected')
-        f.input(type='submit', name='cancel', value='Cancel')
+        f.input(type="submit", name="submit", value="Revert To Selected")
+        f.input(type="submit", name="cancel", value="Cancel")
         return str(h)

--- a/morepath_wiki/tests/test_wiki.py
+++ b/morepath_wiki/tests/test_wiki.py
@@ -12,9 +12,10 @@ def App(tmpdir_factory):
     module.
 
     """
-    from .. import App as _App, path, view   # noqa
+    from .. import App as _App, path, view  # noqa
+
     tmpdir = tmpdir_factory.mktemp(__name__)
-    _App.setting('storage', 'path')(lambda: str(tmpdir))
+    _App.setting("storage", "path")(lambda: str(tmpdir))
     return _App
 
 
@@ -27,98 +28,97 @@ def get_text(response, css_selector):
 def test_create_frontpage(App):
     c = Client(App())
 
-    empty_frontpage = c.get('/').follow()
+    empty_frontpage = c.get("/").follow()
 
-    assert get_text(empty_frontpage, '#title') == \
-        'FrontPage'
-    assert get_text(empty_frontpage, '#content') == \
-        'Page does not exist: edit to create it.'
+    assert get_text(empty_frontpage, "#title") == "FrontPage"
+    assert (
+        get_text(empty_frontpage, "#content")
+        == "Page does not exist: edit to create it."
+    )
 
-    create_form = empty_frontpage.click(linkid='edit-link').form
-    create_form['content'] = 'This is an example'
-    frontpage_v1 = create_form.submit('submit').follow()
+    create_form = empty_frontpage.click(linkid="edit-link").form
+    create_form["content"] = "This is an example"
+    frontpage_v1 = create_form.submit("submit").follow()
 
-    assert get_text(frontpage_v1, '#title') == \
-        'FrontPage'
-    assert get_text(frontpage_v1, '#content') == \
-        'This is an example'
+    assert get_text(frontpage_v1, "#title") == "FrontPage"
+    assert get_text(frontpage_v1, "#content") == "This is an example"
 
 
 def test_noncamelcase_page(App):
     c = Client(App())
 
-    c.get('/foobar', status=404)
+    c.get("/foobar", status=404)
 
 
 def test_abandon_page_creation(App):
     app = App()
     c = Client(app)
 
-    empty_page = c.get('/FooBar')
+    empty_page = c.get("/FooBar")
 
-    assert get_text(empty_page, '#title') == \
-        'FooBar'
-    assert get_text(empty_page, '#content') == \
-        'Page does not exist: edit to create it.'
+    assert get_text(empty_page, "#title") == "FooBar"
+    assert (
+        get_text(empty_page, "#content")
+        == "Page does not exist: edit to create it."
+    )
 
-    create_form = empty_page.click(linkid='edit-link').form
-    create_form['content'] = 'This is an example'
+    create_form = empty_page.click(linkid="edit-link").form
+    create_form["content"] = "This is an example"
 
     # We are sent back to the front page
-    response = create_form.submit('cancel').follow()
-    assert get_text(response, '#title') == \
-        'FrontPage'
+    response = create_form.submit("cancel").follow()
+    assert get_text(response, "#title") == "FrontPage"
 
     # We can also verify that the page is not present in the storage:
     with pytest.raises(KeyError):
-        app.wiki.get_current('FooBar')
+        app.wiki.get_current("FooBar")
 
     with pytest.raises(KeyError):
-        app.wiki.list_page_versions('FooBar')
+        app.wiki.list_page_versions("FooBar")
 
     with pytest.raises(KeyError):
-        app.wiki.revert_page('FooBar', '1')
+        app.wiki.revert_page("FooBar", "1")
 
 
 def test_create_second_version(App):
     c = Client(App())
 
-    page = c.get('/FrontPage')
-    assert get_text(page, '#title') == 'FrontPage'
+    page = c.get("/FrontPage")
+    assert get_text(page, "#title") == "FrontPage"
 
-    create_form = page.click(linkid='edit-link').form
-    create_form['content'] = 'This is a much better example'
-    newversion = create_form.submit('submit').follow()
+    create_form = page.click(linkid="edit-link").form
+    create_form["content"] = "This is a much better example"
+    newversion = create_form.submit("submit").follow()
 
-    assert get_text(newversion, '#title') == 'FrontPage'
-    assert get_text(newversion, '#content') == 'This is a much better example'
+    assert get_text(newversion, "#title") == "FrontPage"
+    assert get_text(newversion, "#content") == "This is a much better example"
 
 
 def test_abandon_revert(App):
     c = Client(App())
 
-    history = c.get('/FrontPage').click(linkid='history-link')
-    assert get_text(history, '#title') == 'History For FrontPage'
+    history = c.get("/FrontPage").click(linkid="history-link")
+    assert get_text(history, "#title") == "History For FrontPage"
 
     revert_form = history.form
-    front = revert_form.submit('cancel').follow()
+    front = revert_form.submit("cancel").follow()
 
-    assert get_text(front, '#title') == 'FrontPage'
-    assert get_text(front, '#content') == 'This is a much better example'
+    assert get_text(front, "#title") == "FrontPage"
+    assert get_text(front, "#content") == "This is a much better example"
 
 
 def test_revert_to_first(App):
     c = Client(App())
 
-    history = c.get('/FrontPage').click(linkid='history-link')
-    assert get_text(history, '#title') == 'History For FrontPage'
+    history = c.get("/FrontPage").click(linkid="history-link")
+    assert get_text(history, "#title") == "History For FrontPage"
 
     revert_form = history.form
-    revert_form['version'] = '1'
-    page = revert_form.submit('submit').follow()
+    revert_form["version"] = "1"
+    page = revert_form.submit("submit").follow()
 
-    assert get_text(page, '#title') == 'FrontPage'
-    assert get_text(page, '#content') == 'This is an example'
+    assert get_text(page, "#title") == "FrontPage"
+    assert get_text(page, "#content") == "This is an example"
 
 
 def test_storage(App):
@@ -126,20 +126,23 @@ def test_storage(App):
     app.commit()
 
     # Version 1 exist:
-    assert app.wiki.retrieve_page('FrontPage', '1') == 'This is an example'
+    assert app.wiki.retrieve_page("FrontPage", "1") == "This is an example"
 
     # Version two has been reverted but not purged:
-    assert app.wiki.retrieve_page('FrontPage', '2') == \
-        'This is a much better example'
+    assert (
+        app.wiki.retrieve_page("FrontPage", "2")
+        == "This is a much better example"
+    )
 
     # Version three does not exist:
     with pytest.raises(KeyError):
-        app.wiki.retrieve_page('FrontPage', '3')
+        app.wiki.retrieve_page("FrontPage", "3")
 
     # You can in fact revert back to version two:
-    app.wiki.revert_page('FrontPage', '2')
-    assert app.wiki.retrieve_page('FrontPage') == \
-        'This is a much better example'
+    app.wiki.revert_page("FrontPage", "2")
+    assert (
+        app.wiki.retrieve_page("FrontPage") == "This is a much better example"
+    )
 
 
 def test_default_storage_directory(tmpdir, monkeypatch):
@@ -147,7 +150,7 @@ def test_default_storage_directory(tmpdir, monkeypatch):
 
     monkeypatch.chdir(tmpdir)
 
-    contents = tmpdir.join('contents')
+    contents = tmpdir.join("contents")
 
     assert not contents.check()
     default_storage_directory()

--- a/morepath_wiki/view.py
+++ b/morepath_wiki/view.py
@@ -6,35 +6,36 @@ from .app import App
 
 @App.html(model=Root)
 def index(self, request):
-    return redirect(request.link(Page('FrontPage')))
+    return redirect(request.link(Page("FrontPage")))
 
 
 with App.html(model=Page) as html:
+
     @html()
     def display(self, request):
         return request.app.wiki.render_page(self.name)
 
-    @html(name='edit')
+    @html(name="edit")
     def edit_form(self, request):
         return request.app.wiki.render_edit_form(self.name)
 
-    @html(name='edit', request_method='POST')
+    @html(name="edit", request_method="POST")
     def edit(self, request):
-        if request.POST.get('submit'):
-            request.app.wiki.store_page(self.name, request.POST['content'])
+        if request.POST.get("submit"):
+            request.app.wiki.store_page(self.name, request.POST["content"])
             return redirect(request.link(self))
-        elif request.POST.get('cancel'):
-            return redirect(request.link(Page('FrontPage')))
+        elif request.POST.get("cancel"):
+            return redirect(request.link(Page("FrontPage")))
 
-    @html(name='history')
+    @html(name="history")
     def history(self, request):
         return request.app.wiki.render_history_form(self.name)
 
-    @html(name='history', request_method='POST')
+    @html(name="history", request_method="POST")
     def revert(self, request):
-        version = request.POST.get('version')
-        if request.POST.get('submit') and version:
+        version = request.POST.get("version")
+        if request.POST.get("submit") and version:
             request.app.wiki.revert_page(self.name, version)
             return redirect(request.link(self))
-        elif request.POST.get('cancel') or not version:
-            return redirect(request.link(Page('FrontPage')))
+        elif request.POST.get("cancel") or not version:
+            return redirect(request.link(Page("FrontPage")))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 80
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.git
+    | \.tox
+    | env
+    | build
+    | dist
+  )/
+  | morepath_wiki/html.py
+)
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[flake8]
+show-source = True
+ignore = E203, E731, W503
+max-line-length = 88
+
+[black]
+exclude = morepath_wiki/html.py
+
+[tool:pytest]
+testpaths = morepath_wiki
+
+[coverage:run]
+omit = morepath_wiki/tests/*
+source = morepath_wiki
+
+[coverage:report]
+show_missing = True
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@ show-source = True
 ignore = E203, E731, W503
 max-line-length = 88
 
-[black]
-exclude = morepath_wiki/html.py
-
 [tool:pytest]
 testpaths = morepath_wiki
 

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,9 @@ setup(
         # 'html', This library has been bundled within the source code.
     ],
     extras_require=dict(
-        test=[
-            'pytest',
-            'pytest-cov',
-            'webtest',
-            'tox',
-        ],
+        test=["pytest >= 2.9.0", "webtest", "pytest-remove-stale-bytecode"],
+        pep8=["flake8", "black"],
+        coverage=["pytest-cov"],
     ),
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -5,24 +5,27 @@ from setuptools import setup, find_packages
 
 
 setup(
-    name='morepath_wiki',
-    version='0.2.dev0',
+    name="morepath_wiki",
+    version="0.2.dev0",
     description=(
-        'A wiki demo for Morepath, based on the '
-        'web micro-framework battle by Richard Jones'),
+        "A wiki demo for Morepath, based on the "
+        "web micro-framework battle by Richard Jones"
+    ),
     long_description=(
-        io.open('README.rst', encoding='utf-8').read() + '\n\n' +
-        io.open('CHANGES.rst', encoding='utf-8').read()),
-    author='Morepath developers',
-    author_email='morepath@googlegroups.com',
+        io.open("README.rst", encoding="utf-8").read()
+        + "\n\n"
+        + io.open("CHANGES.rst", encoding="utf-8").read()
+    ),
+    author="Morepath developers",
+    author_email="morepath@googlegroups.com",
     license="BSD",
     url="https://github.com/morepath/morepath_wiki",
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    keywords='morepath demo',
+    keywords="morepath demo",
     install_requires=[
-        'morepath>=0.14,==0.*',
+        "morepath>=0.14,==0.*",
         # 'html', This library has been bundled within the source code.
     ],
     extras_require=dict(
@@ -31,17 +34,15 @@ setup(
         coverage=["pytest-cov"],
     ),
     entry_points={
-        'console_scripts': [
-            'morepath_wiki = morepath_wiki.__main__:run',
-        ]
+        "console_scripts": ["morepath_wiki = morepath_wiki.__main__:run"]
     },
     classifiers=[
-        'Intended Audience :: Developers',
-        'Environment :: Web Environment',
-        'License :: OSI Approved :: BSD License',
-        'Topic :: Internet :: WWW/HTTP :: WSGI',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-    ]
+        "Intended Audience :: Developers",
+        "Environment :: Web Environment",
+        "License :: OSI Approved :: BSD License",
+        "Topic :: Internet :: WWW/HTTP :: WSGI",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,27 @@
 [tox]
-envlist = py36,py37,py38,pep8,coverage
+envlist = py36, py37, py38, pypy3, coverage, pep8
+skipsdist = True
+skip_missing_interpreters = True
 
 [testenv]
-deps = -e{toxinidir}[test]
-commands = py.test {posargs}
+usedevelop = True
+extras = test
+
+commands = pytest {posargs}
 
 [testenv:pep8]
 basepython = python3.8
-deps = {[testenv]deps}
-	   flake8
-       pep8
+extras = pep8
+
 commands = flake8 morepath_wiki setup.py
+           black --check morepath_wiki setup.py
 
 [testenv:coverage]
 basepython = python3.8
-deps = {[testenv]deps}
-commands =
-    coverage run --source morepath_wiki -m pytest {posargs}
-    coverage report -m --fail-under=100
+extras = test
+         coverage
 
-[pytest]
-testpaths = morepath_wiki
+commands = pytest --cov morepath_wiki --cov-fail-under=100 {posargs}
 
 [flake8]
 exclude = morepath_wiki/html.py


### PR DESCRIPTION
This merge requests adds black for Python to the tools used when running the pep8 compliance tests.

It follows the morepath/reg project so that they now share their test infrastructure more.

The code has been then passed through black.